### PR TITLE
Add tags configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Sidekiq.configure_server do |config|
                 influxdb_client: InfluxDB::Client.new(options), # REQUIRED
                 series_name: 'sidekiq_jobs',                    # optional, default shown
                 retention_policy: nil,                          # optional, default nil
-                start_events: true                              # optional, default true
+                start_events: true,                             # optional, default true
+                tags: { application: 'MyApp' }                  # optional, default {}
   end
 end
 ```
@@ -40,12 +41,12 @@ When you deploy this code, you will start getting the following series in your I
 
     > select * from sidekiq_jobs
     name: sidekiq_jobs
-    time                class  creation_time      error         event  jid                      queue   total              waited              worked
-    ----                -----  -------------      -----         -----  ---                      -----   -----              ------              ------
-    1511707465061000000 FooJob 1511707459.0186539               start  51cc82fe75fbeba37b1ff18f default                    6.042410135269165
-    1511707465061000000 FooJob 1511707459.0186539               finish 51cc82fe75fbeba37b1ff18f default 8.046684265136719  6.042410135269165   2.0042741298675537
-    1511707467068000000 BarJob 1511707461.019835                start  3891f241ab84d3aba728822e default                    6.049134016036987
-    1511707467068000000 BarJob 1511707461.019835  NoMethodError error  3891f241ab84d3aba728822e default 8.056788206100464  6.049134016036987   2.0076541900634766
+    time                application  class  creation_time      error         event  jid                      queue   total              waited              worked
+    ----                -----------  -----  -------------      -----         -----  ---                      -----   -----              ------              ------
+    1511707465061000000 MyApp        FooJob 1511707459.0186539               start  51cc82fe75fbeba37b1ff18f default                    6.042410135269165
+    1511707465061000000 MyApp        FooJob 1511707459.0186539               finish 51cc82fe75fbeba37b1ff18f default 8.046684265136719  6.042410135269165   2.0042741298675537
+    1511707467068000000 MyApp        BarJob 1511707461.019835                start  3891f241ab84d3aba728822e default                    6.049134016036987
+    1511707467068000000 MyApp        BarJob 1511707461.019835  NoMethodError error  3891f241ab84d3aba728822e default 8.056788206100464  6.049134016036987   2.0076541900634766
 
 Tags (repetitive, indexed data — for filtering and grouping by):
 

--- a/lib/sidekiq/influxdb/server_middleware.rb
+++ b/lib/sidekiq/influxdb/server_middleware.rb
@@ -7,12 +7,14 @@ module Sidekiq
         influxdb_client:,
         series_name: 'sidekiq_jobs',
         retention_policy: nil,
-        start_events: true
+        start_events: true,
+        tags: {}
       )
         @influxdb = influxdb_client
         @series = series_name
         @retention = retention_policy
         @start_events = start_events
+        @tags = tags
       end
 
       def call(worker, msg, queue)
@@ -22,7 +24,7 @@ module Sidekiq
             class: worker.class.name,
             queue: queue,
             event: 'start',
-          },
+          }.merge(@tags),
           values: {
             jid:           msg['jid'],
             creation_time: msg['created_at'],


### PR DESCRIPTION
This adds `tags` configuration option, with which you can specify what tags should be pushed to InfluxDB with every event. Helpful when you want to store events from multiple apps in one series. Fixes #1.

I tested it locally although I don't know if I should add some tests too.