### PR TITLE
Reveal original classname on ActiveJob

### DIFF
--- a/lib/sidekiq/middleware/server/influxdb.rb
+++ b/lib/sidekiq/middleware/server/influxdb.rb
@@ -30,7 +30,7 @@ module Sidekiq
           t = Time.now.to_f
           data = {
             tags: {
-              class: worker.class.name,
+              class: class_name(worker, msg),
               queue: queue,
               event: 'start',
             }.merge(@tags),
@@ -61,6 +61,12 @@ module Sidekiq
 
         def save(data)
           @influxdb.write_point(@series, data, precision, @retention)
+        end
+
+        def class_name(worker, job)
+          name = worker.class.name
+          return name unless name == 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper'
+          job['args'].first['job_class']
         end
 
         def precision


### PR DESCRIPTION
When you use ActiveJob with Sidekiq adapter, you'll have all classes `ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper`, which ruins the point of the whole gem