### PR TITLE
Use Process.clock_gettime instead of Time.now

### DIFF
--- a/lib/sidekiq/middleware/server/influxdb.rb
+++ b/lib/sidekiq/middleware/server/influxdb.rb
@@ -27,7 +27,7 @@ module Sidekiq
             yield
             return
           end
-          t = Time.now.to_f
+          t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           data = {
             tags: {
               class: msg['wrapped'] || msg['class'],
@@ -49,7 +49,7 @@ module Sidekiq
             data[:tags][:event] = 'error'
             data[:tags][:error] = e.class.name
           end
-          tt = Time.now.to_f
+          tt = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           data[:values][:worked] = tt - t
           data[:values][:total]  = tt - msg['created_at']
           data[:timestamp] = in_correct_precision(tt)


### PR DESCRIPTION
As per [this article](https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/), `Time.now` is not a reliable way to measure time. Instead `Process.clock_gettime` should be used.

This breaks support for Ruby before 2.1 (I don't know if such old versions are supported anyway).